### PR TITLE
Authoring Experience Improvements 

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -435,7 +435,7 @@ const QuizEditor = () => {
           <div className="wrapper flex" style={{ height: '100vh' }}>
             <div className="main-body">
               <sp-top-nav class="top-nav">
-                <Link to="/">
+                <Link to="/miq-authoring">
                   <sp-top-nav-item>
                     Visual Authoring
                   </sp-top-nav-item>
@@ -455,7 +455,7 @@ const QuizEditor = () => {
               <Routes>
                 <Route path="/quiz-results" element={<QuizResults resultsData={resultsData} />} />
                 <Route path="/debugger" element={<Debugger />} />
-                <Route path="/" element={
+                <Route path="/miq-authoring" element={
                   <ReactFlow
                     nodes={nodes}
                     edges={edges}

--- a/src/components/common/sidebar/Sidebar.css
+++ b/src/components/common/sidebar/Sidebar.css
@@ -1,6 +1,9 @@
 aside {
     padding: 0 20px;
 }
+aside .heading a {
+    display: flex;;
+}
 .spectrum-Button {
     margin: 10px 0 0 0 !important;
 }

--- a/src/components/common/sidebar/Sidebar.jsx
+++ b/src/components/common/sidebar/Sidebar.jsx
@@ -13,8 +13,8 @@ const Sidebar = ({ addQuestion, onImportData, exportData }) => {
     return (
         <aside>
             <div className="heading">
-                <svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 30 26" width="36px" xmlSpace="preserve" aria-hidden="true"> <path fill="#FA0F00" d="M19 0h11v26zM11.1 0H0v26zM15 9.6L22.1 26h-4.6l-2.1-5.2h-5.2z"></path> </svg>
-                <h1 className="spectrum-Heading spectrum-Heading--sizeXS">Quiz Authoring Tool</h1>
+                <a href="/miq-authoring"><svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0" y="0" viewBox="0 0 30 26" width="36px" xmlSpace="preserve" aria-hidden="true"> <path fill="#FA0F00" d="M19 0h11v26zM11.1 0H0v26zM15 9.6L22.1 26h-4.6l-2.1-5.2h-5.2z"></path> </svg>
+                <h1 className="spectrum-Heading spectrum-Heading--sizeXS">Quiz Authoring Tool</h1></a>
             </div>
             <sp-accordion>
                 <sp-accordion-item label="Build New Quiz">

--- a/src/components/pages/QuizResults.jsx
+++ b/src/components/pages/QuizResults.jsx
@@ -6,6 +6,7 @@ import myUseStore from '../../store/Store';
 
 const QuizResults = () => {
   const resultsData = myUseStore(state => state.resultsData);
+  if (!resultsData) return (<div style={{ padding: '1rem' }}>No results found. Please import a quiz to see results here.</div> );
   const { result, 'result-fragments': resultFragments, 'result-destination': resultDestination } = resultsData;
   return (
     <div style={{ padding: '1rem' }}>


### PR DESCRIPTION
Resolves [MWPW-145588](https://jira.corp.adobe.com/browse/MWPW-145588)and [MWPW-145589](https://jira.corp.adobe.com/browse/MWPW-145589), updating paths and existence checks to improve experience. added link back to home in logo as well.

As a result of this, you should be able to:

- See the default home load as /miq-authoring.
- Be able to click Quiz Results without error.
- Have a link back to the home authoring view in the logo.

You can test locally to see the new behaviors, GH pages URL will updated on merge to main.